### PR TITLE
feat: m0 simc docker image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
-DATABASE_URL=postgresql+psycopg://postgres:postgres@db:5432/simforge
-REDIS_URL=redis://localhost:6379
+DATABASE_URL=postgresql://postgres:postgres@db:5432/simforge
+REDIS_URL=redis://redis:6379/0
 NEXT_PUBLIC_API_URL=http://localhost:8000
+SIMC_THREADS=4
+SIMC_TIMEOUT_SEC=120
+SIMC_DEFAULT_CHANNEL=latest
+SIMC_BIN_NIGHTLY=/opt/simc/nightly/simc
+SIMC_BIN_WEEKLY=/opt/simc/weekly/simc

--- a/.github/workflows/simc-weekly.yml
+++ b/.github/workflows/simc-weekly.yml
@@ -1,0 +1,95 @@
+name: Pin Weekly SimC
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  pick-and-build:
+    runs-on: ubuntu-latest
+    env:
+      REPO_NS: simulationcraftorg
+      REPO_NAME: simc
+      TZ: Europe/Berlin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pick first-of-week SimC tag (Europe/Berlin week)
+        id: pick
+        run: |
+          python - <<'PY'
+          import os, sys, requests, datetime, zoneinfo
+          NS=os.environ.get("REPO_NS"); NAME=os.environ.get("REPO_NAME")
+          tz=zoneinfo.ZoneInfo(os.environ.get("TZ","Europe/Berlin"))
+          now=datetime.datetime.now(tz)
+          # Wochenfenster [Mon 00:00, next Mon 00:00) in Berlin-Zeit
+          monday=(now - datetime.timedelta(days=now.weekday())).replace(hour=0,minute=0,second=0,microsecond=0)
+          next_monday=monday + datetime.timedelta(days=7)
+          start=monday.astimezone(datetime.timezone.utc)
+          end=next_monday.astimezone(datetime.timezone.utc)
+
+          def fetch_tags(page=1, page_size=100):
+            url=f"https://hub.docker.com/v2/repositories/{NS}/{NAME}/tags/?page_size={page_size}&page={page}&ordering=last_updated"
+            r=requests.get(url, timeout=30)
+            r.raise_for_status()
+            return r.json()
+
+          # Sammle ein paar Seiten, filtere auf diese Woche (UTC), ohne 'latest'
+          from dateutil.parser import isoparse
+          results=[]
+          page=1
+          while page<=5:
+            data=fetch_tags(page)
+            for it in data.get("results",[]):
+              name=it.get("name")
+              if name=="latest": 
+                continue
+              lu=isoparse(it.get("last_updated"))
+              if start <= lu < end:
+                results.append((lu, name))
+            if not data.get("next"):
+              break
+            page+=1
+
+          # Fallback: wenn leer, nimm Vorwoche (gleiches Verfahren)
+          if not results:
+            prev_start=start - datetime.timedelta(days=7)
+            prev_end=start
+            page=1
+            while page<=5:
+              data=fetch_tags(page)
+              for it in data.get("results",[]):
+                name=it.get("name")
+                if name=="latest": 
+                  continue
+                lu=isoparse(it.get("last_updated"))
+                if prev_start <= lu < prev_end:
+                  results.append((lu, name))
+              if not data.get("next"):
+                break
+              page+=1
+
+          if not results:
+            print("No suitable tags found.", file=sys.stderr)
+            sys.exit(1)
+
+          # Frühestes Datum der (aktuellen oder fallback) Woche
+          pick=min(results, key=lambda t: t[0])[1]
+          with open(os.environ["GITHUB_OUTPUT"],"a") as f:
+            f.write(f"simc_weekly_tag={pick}\n")
+          print("Picked weekly tag:", pick)
+          PY
+
+      - name: Build worker with weekly tag
+        run: |
+          docker build --platform=linux/amd64 \
+            -f apps/worker/Dockerfile \
+            --build-arg SIMC_WEEKLY_TAG=${{ steps.pick.outputs.simc_weekly_tag }} \
+            -t suitablyat/worker:weekly .
+
+      - name: Push (optional)
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USER }}" --password-stdin
+          docker push suitablyat/worker:weekly

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,7 +1,24 @@
-FROM python:3.12-slim
+ARG SIMC_WEEKLY_TAG=1120-2025-09-02-c9cad05
+
+FROM --platform=linux/amd64 simulationcraftorg/simc:latest AS simc_nightly
+FROM --platform=linux/amd64 simulationcraftorg/simc:${SIMC_WEEKLY_TAG} AS simc_weekly
+FROM --platform=linux/amd64 simulationcraftorg/simc:latest
+
+RUN apk add --no-cache python3 py3-pip py3-virtualenv ca-certificates libstdc++ libgcc
+
+RUN python3 -m venv /opt/venv && /opt/venv/bin/python -m ensurepip
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+RUN mkdir -p /opt/simc/nightly /opt/simc/weekly \
+ && cp -a /app/SimulationCraft/. /opt/simc/nightly/ \
+ && ln -sf /opt/simc/nightly/simc /usr/local/bin/simc
+COPY --from=simc_weekly /app/SimulationCraft /opt/simc/weekly
+
 WORKDIR /app
-COPY pyproject.toml /app/
-RUN pip install --no-cache-dir rq redis pydantic
-COPY worker /app/worker
-ENV REDIS_URL=redis://redis:6379/0
-CMD ["python", "-m", "worker.main"]
+COPY apps/worker/requirements.txt .
+RUN pip install --upgrade pip setuptools wheel \
+ && pip install --no-cache-dir -r requirements.txt
+COPY apps/worker/ ./
+
+ENTRYPOINT ["python", "-m", "worker.main"]

--- a/apps/worker/requirements.txt
+++ b/apps/worker/requirements.txt
@@ -1,3 +1,7 @@
 celery>=5.4
 redis>=5.0
 psycopg[binary]>=3.2
+rq==1.16.2
+redis==5.0.7
+pydantic==2.8.2
+python-dotenv==1.0.1

--- a/apps/worker/smoke.py
+++ b/apps/worker/smoke.py
@@ -1,0 +1,2 @@
+from worker.simc_runner import run_simc
+print(run_simc("iterations=1\noptimal_raid=1\narmory=eu,blackmoore,suitw", channel="latest").keys())

--- a/apps/worker/worker/jobs.py
+++ b/apps/worker/worker/jobs.py
@@ -1,0 +1,10 @@
+from .schemas import SimJobRequest, SimJobResult
+from .simc_runner import run_simc, SimcError
+
+def run_sim_job(payload: dict) -> dict:
+    req = SimJobRequest(**payload)
+    try:
+        data = run_simc(req.input_text)
+        return SimJobResult(ok=True, data=data).model_dump()
+    except SimcError as e:
+        return SimJobResult(ok=False, error=str(e)).model_dump()

--- a/apps/worker/worker/schemas.py
+++ b/apps/worker/worker/schemas.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Field
+
+class SimJobRequest(BaseModel):
+    input_text: str = Field(min_length=1, description="Full .simc input")
+
+class SimJobResult(BaseModel):
+    ok: bool
+    data: dict | None = None
+    error: str | None = None

--- a/apps/worker/worker/settings.py
+++ b/apps/worker/worker/settings.py
@@ -1,0 +1,18 @@
+import os
+from pydantic import BaseModel, Field
+
+class Settings(BaseModel):
+    redis_url: str = Field(default_factory=lambda: os.getenv("REDIS_URL", "redis://redis:6379/0"))
+    simc_bin: str | None = Field(default_factory=lambda: os.getenv("SIMC_BIN", None))
+    simc_bin_nightly: str = Field(
+        default_factory=lambda: os.getenv("SIMC_BIN_NIGHTLY", "/opt/simc/nightly/simc")
+    )
+    simc_bin_weekly: str = Field(
+        default_factory=lambda: os.getenv("SIMC_BIN_WEEKLY", "/opt/simc/weekly/simc")
+    )
+    simc_default_channel: str = Field(default_factory=lambda: os.getenv("SIMC_DEFAULT_CHANNEL", "latest"))
+    simc_threads: int = int(os.getenv("SIMC_THREADS", "4"))
+    simc_timeout_sec: int = int(os.getenv("SIMC_TIMEOUT_SEC", "120"))
+    simc_log_dir: str = os.getenv("SIMC_LOG_DIR", "/app/logs")
+
+settings = Settings()

--- a/apps/worker/worker/simc_runner.py
+++ b/apps/worker/worker/simc_runner.py
@@ -1,0 +1,105 @@
+import json
+import tempfile
+import pathlib
+import subprocess
+import time
+
+from .settings import settings
+
+class SimcError(RuntimeError):
+    ...
+
+def resolve_simc_bin(channel: str | None) -> pathlib.Path:
+    """
+    Wählt das passende simc-Binary je nach Channel.
+    Reihenfolge:
+      1) SIMC_BIN (harte ENV-Override) -> ignoriert Channel komplett
+      2) nightly/latest -> settings.simc_bin_nightly
+      3) weekly -> settings.simc_bin_weekly (Fallback: nightly, falls weekly fehlt)
+    """
+    # 1) harter Override
+    if settings.simc_bin:
+        p = pathlib.Path(settings.simc_bin)
+        if not p.exists():
+            raise SimcError(f"SIMC_BIN override not found at: {p}")
+        return p
+
+    # 2) Channel-Logik
+    c = (channel or settings.simc_default_channel or "latest").lower()
+    if c in ("latest", "nightly"):
+        p = pathlib.Path(settings.simc_bin_nightly)
+    elif c == "weekly":
+        p = pathlib.Path(settings.simc_bin_weekly)
+        if not p.exists():
+            # Fallback, falls weekly noch nicht eingebaut/gebaut wurde
+            p = pathlib.Path(settings.simc_bin_nightly)
+    else:
+        raise SimcError(f"Unknown simc channel '{channel}'. Use: latest|nightly|weekly")
+
+    if not p.exists():
+        raise SimcError(f"simc binary not found at {p}")
+    return p
+
+def run_simc(simc_input: str, channel: str | None = None) -> dict:
+    """
+    Führt SimulationCraft aus.
+    - schreibt Input in eine temp-Datei
+    - bevorzugt JSON-Ausgabe via 'json2=<file>'
+    - loggt stdout/stderr in /app/logs (konfigurierbar)
+    """
+    bin_path = resolve_simc_bin(channel)
+
+    # Log-Dateien anlegen
+    log_dir = pathlib.Path(settings.simc_log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    ch = (channel or settings.simc_default_channel or "latest").lower()
+    base = log_dir / f"simc_{ch}_{ts}"
+    stdout_log = base.with_suffix(".out.log")
+    stderr_log = base.with_suffix(".err.log")
+
+    with tempfile.TemporaryDirectory() as td:
+        td = pathlib.Path(td)
+        in_file = td / "input.simc"
+        out_file = td / "result.json"
+        in_file.write_text(simc_input, encoding="utf-8")
+
+        cmd = [
+            str(bin_path),
+            f"input={in_file}",
+            f"json2={out_file}",
+            f"threads={settings.simc_threads}",
+        ]
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=settings.simc_timeout_sec,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise SimcError(f"simc timeout after {settings.simc_timeout_sec}s (channel={ch})") from e
+
+        # Logs persistieren
+        stdout_log.write_text(proc.stdout or "", encoding="utf-8")
+        stderr_log.write_text(proc.stderr or "", encoding="utf-8")
+
+        if proc.returncode != 0:
+            raise SimcError(f"simc failed (exit {proc.returncode}) — see {stderr_log}")
+
+        if out_file.exists():
+            try:
+                return json.loads(out_file.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                # Fallback: stdout als JSON versuchen
+                pass
+
+        if proc.stdout:
+            try:
+                return json.loads(proc.stdout)
+            except Exception:
+                return {"stdout": proc.stdout}
+
+        raise SimcError("simc produced no output")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: simforge
-    ports:
-      - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -31,9 +29,6 @@ services:
       dockerfile: apps/api/Dockerfile
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     env_file: .env
-    environment:
-      DATABASE_URL: ${DATABASE_URL}
-      REDIS_URL: ${REDIS_URL}
     volumes:
       - ./apps/api:/app
     ports:
@@ -50,16 +45,21 @@ services:
       retries: 5
 
   worker:
+    platform: linux/amd64
     build:
-      context: ./apps/worker
-      dockerfile: Dockerfile.dev
-    command: bash -lc "python -m celery -A worker_app worker --loglevel=info"
+      context: .
+      dockerfile: apps/worker/Dockerfile
+    entrypoint: []
+    command: [ "python", "-m", "worker.main" ]
     env_file: .env
-    environment:
-      DATABASE_URL: ${DATABASE_URL}
-      REDIS_URL: ${REDIS_URL}
     volumes:
       - ./apps/worker:/app
+    healthcheck:
+      test: ["CMD", "/opt/simc/nightly/simc", "version=1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
       api:
         condition: service_healthy
@@ -72,8 +72,6 @@ services:
       dockerfile: Dockerfile.dev
     command: npm run dev -- -p 3000 -H 0.0.0.0
     env_file: .env
-    environment:
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
     volumes:
       - ./apps/web:/app
       - /app/node_modules

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,0 +1,241 @@
+Excellent – below is a **fully restructured, cleaned-up version of the `AGENT_REQUIREMENTS.md`** file, written clearly and concisely for someone starting the project from scratch with **no prior context**.
+
+All unnecessary background, comparisons, history, and post-MVP decisions have been removed. This version is **strictly focused on building the MVP**, and assumes the reader is a developer or technical contributor who will implement the system based on this document.
+
+---
+
+# REQUIREMENTS.md
+
+## 1. Overview
+
+This project is a web application that allows users to run **SimulationCraft (SimC)** simulations for World of Warcraft characters and view the results. The application provides a **simple form** to submit a simulation job, runs it in the background, and streams **real-time status updates and logs** to the user.
+
+The application architecture is based on a **frontend–API–worker model**, with Redis for background job processing and PostgreSQL for data storage. All simulations are **anonymous** and there is no monetization or user account system in the MVP.
+
+---
+
+## 2. Features (MVP)
+
+### Required:
+
+* Submit a **Quick Sim** job with SimC input text
+* Backend runs the simulation using a pre-installed SimC binary
+* User receives **live updates** during job execution via **Server-Sent Events (SSE)**
+* On completion, the user can:
+
+  * View the result summary (e.g., DPS)
+  * Download result JSON and logs
+* All jobs are anonymous and public via an unguessable ID
+
+---
+
+## 3. System Architecture
+
+### 3.1 Components
+
+| Component          | Description                                                                  |
+| ------------------ | ---------------------------------------------------------------------------- |
+| **Frontend**       | Single Page App (SPA) built with Next.js. Communicates only with the API.    |
+| **API Server**     | REST API built with FastAPI. Accepts jobs, streams events, serves artifacts. |
+| **Worker**         | Celery-based background job processor that runs SimC jobs.                   |
+| **PostgreSQL**     | Stores job metadata and metrics.                                             |
+| **Redis**          | Used for task queueing (Celery) and optional event buffering.                |
+| **Docker Compose** | Used to run all services locally for development and testing.                |
+
+---
+
+## 4. User Flow
+
+1. User opens the web app and pastes SimC input into a form
+2. User selects the SimC channel: `nightly`, `latest`, or `weekly`
+3. User submits the job via the API
+4. API returns a unique job ID
+5. Frontend opens an SSE stream to `/sims/{id}/events`
+6. Worker processes the job and emits events (stage changes, logs, errors, final status)
+7. After the job completes:
+
+   * User sees DPS summary and can download the result files
+
+---
+
+## 5. SimC Integration
+
+* **SimC Input**: Provided as plain text from the user
+* **Binary execution**: The worker runs SimC using the CLI binary mounted at a configurable path
+* **Channels**:
+
+  * `nightly`: updated every night
+  * `latest`: current build
+  * `weekly`: built every Monday at 10:45 PM EST
+* **Input handling**:
+
+  * Input is saved to a temp file
+  * The SimC binary is executed with that file as input
+* **Output**:
+
+  * JSON result is parsed and stored
+  * stdout and stderr are captured
+* **Failure cases**:
+
+  * Timeouts
+  * Invalid input (“Nothing to sim!”)
+  * Binary/runtime errors
+
+---
+
+## 6. API Endpoints
+
+| Method | Path                   | Description                         |
+| ------ | ---------------------- | ----------------------------------- |
+| `GET`  | `/health`              | Health check endpoint               |
+| `POST` | `/sims`                | Submit a new simulation job         |
+| `GET`  | `/sims/{id}`           | Fetch job status and metadata       |
+| `GET`  | `/sims/{id}/artifacts` | List result and log files           |
+| `GET`  | `/sims/{id}/log`       | View or download stderr/stdout      |
+| `GET`  | `/sims/{id}/events`    | Open an SSE stream for live updates |
+
+---
+
+## 7. Live Event Stream (SSE)
+
+The API provides real-time updates using **Server-Sent Events** via the `/sims/{id}/events` endpoint.
+
+### Format:
+
+Each event contains:
+
+* `event`: event type (string)
+* `id`: unique event ID (incrementing per job)
+* `data`: JSON payload
+* All events include a `trace_id` for logging
+
+### Event Types:
+
+| Event            | Description                                      |
+| ---------------- | ------------------------------------------------ |
+| `job.accepted`   | Job successfully submitted                       |
+| `job.started`    | Worker started the job                           |
+| `job.stage`      | Phase marker (e.g., `run_simc`, `parse_results`) |
+| `job.progress`   | Optional numeric progress or ETA                 |
+| `log.stdout`     | Output from SimC stdout                          |
+| `log.stderr`     | Output from SimC stderr                          |
+| `artifact.ready` | A new artifact is available                      |
+| `job.warning`    | Warning during processing                        |
+| `job.error`      | Error occurred during execution                  |
+| `job.finished`   | Job is completed (success or failure)            |
+| `heartbeat`      | Keep-alive event                                 |
+
+### Behavior:
+
+* Events must be sent in order
+* Event stream stays open until job finishes
+* After completion, stream remains open for a short time (e.g. 30 minutes) for client reconnect
+* Client may reconnect using `Last-Event-ID` header
+
+---
+
+## 8. Database Models
+
+### Table: `sims`
+
+* `id`: UUID (primary key)
+* `status`: pending | running | success | failed
+* `channel`: nightly | latest | weekly
+* `simc_input`: text
+* `created_at`, `started_at`, `finished_at`: timestamps
+* `trace_id`: string
+
+### Table: `artifacts`
+
+* `id`: UUID
+* `sim_id`: foreign key
+* `kind`: result\_json | report\_html | stderr | stdout
+* `url` or `path`: storage reference
+* `size`: in bytes
+* `created_at`: timestamp
+
+### Table: `metrics`
+
+* `sim_id`: foreign key
+* `wall_time`: seconds
+* `iterations`: int
+* `dps_mean`, `dps_stddev`: float
+
+---
+
+## 9. Worker (Celery)
+
+* **Queue**: All jobs go through Redis queue
+* **Retries**: Up to 2 automatic retries on failure
+* **Timeouts**: Each job has a maximum execution time
+* **Artifacts**:
+
+  * stdout/stderr are saved to files
+  * JSON result is stored and parsed
+* **Error Handling**:
+
+  * SimC errors are returned as structured payloads
+  * Logs are always available for debugging
+
+---
+
+## 10. Frontend Requirements
+
+* Single Page App using Next.js and TypeScript
+* Quick Sim submission form with validation
+* Status page that connects to the SSE endpoint and displays:
+
+  * Progress stages
+  * Logs (stdout, stderr)
+  * Final result summary (e.g. DPS)
+* Download links for result and log files
+* Fallback polling if SSE fails
+* No login or account system
+
+---
+
+## 11. Environment Configuration
+
+All services must be configurable using environment variables:
+
+### Required ENV variables:
+
+* `DATABASE_URL`
+* `REDIS_URL`
+* `SIMC_CHANNEL`
+* `SIMC_BINARY_PATH`
+* `NEXT_PUBLIC_API_URL` (for frontend)
+
+---
+
+## 12. Local Development (Docker)
+
+Use Docker Compose to start all services locally:
+
+* PostgreSQL
+* Redis
+* API
+* Worker
+* Frontend
+
+Example `make` targets:
+
+* `make dev` — start stack
+* `make down` — stop stack
+* `make logs` — tail logs
+* `make migrate` — apply database migrations
+
+---
+
+## 13. Definition of Done (MVP)
+
+* Job submission via API works
+* SSE provides real-time job updates
+* SimC job is executed and returns result
+* Logs and artifacts are stored and accessible
+* Frontend can:
+  * Submit jobs
+  * Show live progress
+  * Display results
+* System runs locally with Docker Compose
+* No login or monetization features


### PR DESCRIPTION
### 🚀 Add Docker Image for SimulationCraft (SimC)

This PR adds a working Docker image that includes the SimulationCraft (SimC) binary and makes it accessible for further integration.

### ✅ What's Included

* Dockerfile that installs a nightly version of SimC from the official repo
* Docker image built and tested locally
* Initial integration with `docker-compose`
* SimC can be executed inside the container (e.g., `simc --version` works)

### 🧪 How to Test

Run the following to build and test locally:

```bash
docker compose build worker
docker compose run worker /opt/simc/nightly/simc
```

### 📌 Notes

* This is the foundation for running real simulation jobs.
* No frontend or job queuing integration yet — that will follow in upcoming issues.

Closes #7